### PR TITLE
Update screenshots display size

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,7 @@ more about developer facing aspects of Android accessibility, read the
 Screenshots
 -----------
 
-![Home Screen TalkBack](screenshots/talkback_home.png "Task list screen with TalkBack on"){width=240px}
-![Detail](screenshots/detail_dark.png "Detail screen in dark mode"){width=240px}
-![Edit](screenshots/edit.png "Task edit screen"){width=240px}
+<img src="screenshots/talkback_home.png" width="240" title="Task list screen with TalkBack on"> <img src="screenshots/detail_dark.png" width="240" title="Detail screen in dark mode"> <img src="screenshots/edit.png" width="240" title="Task edit screen">
 
 Issues
 -----------


### PR DESCRIPTION
Screenshots is not displayed properly in Readme, it display large images vertically

After this changes:

![Screen Shot 2021-09-12 at 20 02 41](https://user-images.githubusercontent.com/182110/132988628-9a68426e-3d1c-46b2-8962-41f8b573583b.png)
