### PR TITLE
Replace use of GlobalScope with Application CouroutineScope

### DIFF
--- a/shared/src/main/java/com/example/android/trackr/di/AppModule.kt
+++ b/shared/src/main/java/com/example/android/trackr/di/AppModule.kt
@@ -30,8 +30,9 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import java.time.Clock
 import javax.inject.Singleton
@@ -45,7 +46,13 @@ object AppModule {
 
     @Provides
     @Singleton
-    fun provideDatabase(@ApplicationContext context: Context): AppDatabase {
+    fun provideAppCoroutineScope(): CoroutineScope {
+        return CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    }
+
+    @Provides
+    @Singleton
+    fun provideDatabase(@ApplicationContext context: Context, appCoroutineScope: CoroutineScope): AppDatabase {
         appDatabase = Room.databaseBuilder(
             context,
             AppDatabase::class.java,
@@ -55,7 +62,7 @@ object AppModule {
             .addCallback(object : RoomDatabase.Callback() {
                 override fun onCreate(db: SupportSQLiteDatabase) {
                     super.onCreate(db)
-                    GlobalScope.launch(Dispatchers.IO) {
+                    appCoroutineScope.launch(Dispatchers.IO) {
                         insertSeedData()
                     }
                 }


### PR DESCRIPTION
I noticed that the current usage of `GlobalScope` while seeding the initial database is not ideal, for the reasons mentioned in the following article
https://elizarov.medium.com/the-reason-to-avoid-globalscope-835337445abc
Hence I would like to propose a pull request to replace usage of `GlobalScope` with `Application CoroutineScope`
#40 