### PR TITLE
Switch CI to use Java 11

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: set up JDK 1.8
+      - name: set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Prepare script
         run: chmod +x .github/scripts/gradlew_recursive.sh
       - name: Build project


### PR DESCRIPTION
Upgrades GitHub Actions to use Java 11 instead of 8.